### PR TITLE
Update `__HIP_PLATFORM_*__` macros for ROCm 6.0

### DIFF
--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -61,7 +61,7 @@ target_compile_options(hipsparselt-bench PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${COM
 if( NOT BUILD_CUDA )
   target_link_libraries( hipsparselt-bench PRIVATE hip::host hip::device )
 else()
-  target_compile_definitions( hipsparselt-bench PRIVATE __HIP_PLATFORM_NVCC__ )
+  target_compile_definitions( hipsparselt-bench PRIVATE __HIP_PLATFORM_NVIDIA__ )
   target_include_directories( hipsparselt-bench
     PRIVATE
       $<BUILD_INTERFACE:${CUDA_INCLUDE_DIRS}>

--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -90,7 +90,7 @@ struct perf_sparse<
     Tc,
     TBias,
     std::enable_if_t<
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef __HIP_PLATFORM_AMD__
         (std::is_same<Ti, To>{} && (std::is_same<Ti, __half>{} || std::is_same<Ti, hip_bfloat16>{})
          && std::is_same<Tc, float>{})
 #else
@@ -527,7 +527,7 @@ try
     bool is_f16      = arg.a_type == HIPSPARSELT_R_16F || arg.a_type == HIPSPARSELT_R_16BF;
     bool is_f32      = arg.a_type == HIPSPARSELT_R_32F;
     arg.compute_type = compute_type == ""
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef __HIP_PLATFORM_AMD__
                            ? (is_f16 ? HIPSPARSELT_COMPUTE_32F : HIPSPARSELT_COMPUTE_32I)
 #else
                            ? (is_f16   ? HIPSPARSELT_COMPUTE_16F

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -60,7 +60,7 @@ target_link_libraries( hipsparselt-test PRIVATE ${BLAS_LIBRARY} ${GTEST_BOTH_LIB
 if( NOT BUILD_CUDA )
   target_link_libraries( hipsparselt-test PRIVATE hip::host hip::device )
 else()
-  target_compile_definitions( hipsparselt-test PRIVATE __HIP_PLATFORM_NVCC__ )
+  target_compile_definitions( hipsparselt-test PRIVATE __HIP_PLATFORM_NVIDIA__ )
   target_include_directories( hipsparselt-test
     PRIVATE
       $<BUILD_INTERFACE:${CUDA_INCLUDE_DIRS}>

--- a/clients/include/hipsparselt_math.hpp
+++ b/clients/include/hipsparselt_math.hpp
@@ -37,7 +37,7 @@
 
 inline __host__ hip_bfloat16 float_to_bfloat16_truncate(float val)
 {
-#if defined(__HIP_PLATFORM_HCC__)
+#if defined(__HIP_PLATFORM_AMD__)
     return hip_bfloat16(val, hip_bfloat16::truncate_t::truncate);
 #else
     return __float2bfloat16_rd(val);
@@ -65,7 +65,7 @@ template <>
 inline hip_bfloat16 negate(hip_bfloat16 x)
 {
 
-#if defined(__HIP_PLATFORM_HCC__)
+#if defined(__HIP_PLATFORM_AMD__)
     x.data ^= 0x8000;
     return x;
 #else

--- a/clients/include/hipsparselt_random.hpp
+++ b/clients/include/hipsparselt_random.hpp
@@ -218,7 +218,7 @@ inline float random_generator()
 template <>
 inline __half random_generator<__half>()
 {
-#if defined(__HIP_PLATFORM_HCC__)
+#if defined(__HIP_PLATFORM_AMD__)
 #define CAST
 #else
 #define CAST static_cast<float>
@@ -231,7 +231,7 @@ inline __half random_generator<__half>()
 template <>
 inline hip_bfloat16 random_generator<hip_bfloat16>()
 {
-#if defined(__HIP_PLATFORM_HCC__)
+#if defined(__HIP_PLATFORM_AMD__)
 #define CAST
 #else
 #define CAST static_cast<float>

--- a/clients/include/spmm/testing_compress.hpp
+++ b/clients/include/spmm/testing_compress.hpp
@@ -285,7 +285,7 @@ void testing_compress_bad_arg(const Arguments& arg)
         hipsparseLtSpMMACompress2(handle, nullptr, true, transA, dA, dA_1, dA_ws, stream),
         HIPSPARSE_STATUS_INVALID_VALUE);
 
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef __HIP_PLATFORM_AMD__
     EXPECT_HIPSPARSE_STATUS(
         hipsparseLtSpMMACompress2(handle, matA, false, transA, dA, dA_1, dA_ws, stream),
         HIPSPARSE_STATUS_INTERNAL_ERROR);
@@ -592,7 +592,7 @@ void testing_compress(const Arguments& arg)
                                    reinterpret_cast<Ti*>(hA_1.data()),
                                    num_batches);
 // cusparselt' metadata has different layout so skip metadata check.
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef __HIP_PLATFORM_AMD__
             unit_check_general<int8_t>(M,
                                        K / 8,
                                        M,
@@ -612,7 +612,7 @@ void testing_compress(const Arguments& arg)
                                                       reinterpret_cast<Ti*>(hA_1.data()),
                                                       num_batches);
 // cusparselt' metadata has different layout so skip metadata check.
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef __HIP_PLATFORM_AMD__
             hipsparselt_error_m
                 = unit_check_diff<int8_t>(M,
                                           K / 8,

--- a/clients/include/spmm/testing_spmm.hpp
+++ b/clients/include/spmm/testing_spmm.hpp
@@ -498,7 +498,7 @@ void testing_spmm(const Arguments& arg)
             hipsparseLtMatmulDescSetAttribute(
                 handle, matmul, HIPSPARSELT_MATMUL_BIAS_STRIDE, &bias_stride, sizeof(int64_t)),
             HIPSPARSE_STATUS_SUCCESS);
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef __HIP_PLATFORM_AMD__
         EXPECT_HIPSPARSE_STATUS(hipsparseLtMatmulDescSetAttribute(handle,
                                                                   matmul,
                                                                   HIPSPARSELT_MATMUL_BIAS_TYPE,

--- a/clients/include/testing_auxiliary.hpp
+++ b/clients/include/testing_auxiliary.hpp
@@ -94,7 +94,7 @@ void testing_aux_mat_init_dense_bad_arg(const Arguments& arg)
             handle_, &m_descr, row, col, 0, 16, arg.a_type, HIPSPARSE_ORDER_COL),
         HIPSPARSE_STATUS_INVALID_VALUE);
 
-#ifdef __HIP_PLATFORM_NVCC__
+#ifdef __HIP_PLATFORM_NVIDIA__
     EXPECT_HIPSPARSE_STATUS(
         hipsparseLtDenseDescriptorInit(
             handle_, &m_descr, row, col, 129, 16, arg.a_type, HIPSPARSE_ORDER_COL),
@@ -105,7 +105,7 @@ void testing_aux_mat_init_dense_bad_arg(const Arguments& arg)
         HIPSPARSE_STATUS_NOT_SUPPORTED);
 #endif
 
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef __HIP_PLATFORM_AMD__
     EXPECT_HIPSPARSE_STATUS(
         hipsparseLtDenseDescriptorInit(
             handle_, &m_descr, row, col, ld, 16, arg.a_type, HIPSPARSE_ORDER_ROW),
@@ -216,7 +216,7 @@ void testing_aux_mat_init_structured_bad_arg(const Arguments& arg)
                                                                 HIPSPARSE_ORDER_COL,
                                                                 HIPSPARSELT_SPARSITY_50_PERCENT),
 
-#ifdef __HIP_PLATFORM_NVCC__
+#ifdef __HIP_PLATFORM_NVIDIA__
                             HIPSPARSE_STATUS_NOT_SUPPORTED
 #else
                             HIPSPARSE_STATUS_SUCCESS
@@ -234,7 +234,7 @@ void testing_aux_mat_init_structured_bad_arg(const Arguments& arg)
                                                                 HIPSPARSELT_SPARSITY_50_PERCENT),
                             HIPSPARSE_STATUS_INVALID_VALUE);
 
-#ifdef __HIP_PLATFORM_NVCC__
+#ifdef __HIP_PLATFORM_NVIDIA__
     EXPECT_HIPSPARSE_STATUS(hipsparseLtStructuredDescriptorInit(handle,
                                                                 &m_descr,
                                                                 row,
@@ -247,7 +247,7 @@ void testing_aux_mat_init_structured_bad_arg(const Arguments& arg)
                             HIPSPARSE_STATUS_NOT_SUPPORTED);
 #endif
 
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef __HIP_PLATFORM_AMD__
     EXPECT_HIPSPARSE_STATUS(hipsparseLtStructuredDescriptorInit(handle,
                                                                 &m_descr,
                                                                 row,
@@ -585,7 +585,7 @@ void testing_aux_matmul_init_bad_arg(const Arguments& arg)
             handle, &m_descr, opA, opB, matA, matB, matC, nullptr, arg.compute_type),
         HIPSPARSE_STATUS_INVALID_VALUE);
 
-#ifdef __HIP_PLATFORM_NVCC__
+#ifdef __HIP_PLATFORM_NVIDIA__
     if(arg.a_type == HIPSPARSELT_R_8I)
         EXPECT_HIPSPARSE_STATUS(
             hipsparseLtMatmulDescriptorInit(
@@ -601,7 +601,7 @@ void testing_aux_matmul_init_bad_arg(const Arguments& arg)
         tmpComputeType = HIPSPARSELT_COMPUTE_32I;
         break;
     default:
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef __HIP_PLATFORM_AMD__
         tmpComputeType = HIPSPARSELT_COMPUTE_32F;
 #else
         tmpComputeType = HIPSPARSELT_COMPUTE_16F;
@@ -629,7 +629,7 @@ void testing_aux_matmul_init_bad_arg(const Arguments& arg)
         HIPSPARSE_STATUS_INVALID_VALUE);
 
     //Singal abort at CUDA backend
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef __HIP_PLATFORM_AMD__
     EXPECT_HIPSPARSE_STATUS(
         hipsparseLtMatmulDescriptorInit(
             handle, &m_descr, opA, opB, matA, matB, mat_112_112, matD, arg.compute_type),
@@ -670,7 +670,7 @@ void testing_aux_matmul_init_bad_arg(const Arguments& arg)
             handle, &m_descr, opA, opB, matA, matB_, matC, matD, arg.compute_type),
         HIPSPARSE_STATUS_NOT_SUPPORTED);
 
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef __HIP_PLATFORM_AMD__
     EXPECT_HIPSPARSE_STATUS(
         hipsparseLtMatmulDescriptorInit(
             handle, &m_descr, opA, opB, matA, matB, matC_, matD, arg.compute_type),
@@ -875,7 +875,7 @@ void testing_aux_matmul_get_attr_bad_arg(const Arguments& arg)
             handle, matmul, HIPSPARSELT_MATMUL_ACTIVATION_RELU_UPPERBOUND, &data64, 1),
         HIPSPARSE_STATUS_INVALID_VALUE);
 
-#ifdef __HIP_PLATFORM_NVCC__
+#ifdef __HIP_PLATFORM_NVIDIA__
     void* dBias;
     hipMalloc((void**)&dBias, (M) * sizeof(float));
     EXPECT_HIPSPARSE_STATUS(hipsparseLtMatmulDescGetAttribute(
@@ -935,7 +935,7 @@ void testing_aux_matmul_set_get_bias_vector(const Arguments& arg)
         hipsparseLtMatmulDescSetAttribute(
             handle, matmul, HIPSPARSELT_MATMUL_BIAS_POINTER, &_dBias, sizeof(void *)),
         HIPSPARSE_STATUS_SUCCESS);
-  
+
     void *dBias_r;
     EXPECT_HIPSPARSE_STATUS(
         hipsparseLtMatmulDescGetAttribute(
@@ -944,7 +944,7 @@ void testing_aux_matmul_set_get_bias_vector(const Arguments& arg)
 
     CHECK_HIP_ERROR(
         hipMemcpy(hBias, dBias_r, sizeof(float) * M, hipMemcpyDeviceToHost));
-   
+
     unit_check_general<float>(M, 1, M, M, hBias_gold, hBias, 1);
 }
 
@@ -1309,7 +1309,7 @@ void testing_aux_matmul_alg_set_attr_bad_arg(const Arguments& arg)
             handle, alg_sel, HIPSPARSELT_MATMUL_ALG_CONFIG_MAX_ID, &data, sizeof(data)),
         HIPSPARSE_STATUS_INVALID_VALUE);
 
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef __HIP_PLATFORM_AMD__
     //TODO hip backend not support split k yet. Remove this test once hip backend support splitk
     EXPECT_HIPSPARSE_STATUS(hipsparseLtMatmulAlgSetAttribute(
                                 handle, alg_sel, HIPSPARSELT_MATMUL_SPLIT_K, &data, sizeof(data)),
@@ -1564,7 +1564,7 @@ void testing_aux_get_workspace_size_bad_arg(const Arguments& arg)
     EXPECT_HIPSPARSE_STATUS(hipsparseLtMatmulGetWorkspace(handle, nullptr, &workspace_size),
                             HIPSPARSE_STATUS_INVALID_VALUE);
 
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef __HIP_PLATFORM_AMD__
 
     EXPECT_HIPSPARSE_STATUS(hipsparseLtMatmulGetWorkspace(handle, &plan_, &workspace_size),
                             HIPSPARSE_STATUS_INVALID_VALUE);

--- a/clients/include/unit.hpp
+++ b/clients/include/unit.hpp
@@ -76,7 +76,7 @@
 
 //#define ASSERT_HALF_EQ(a, b) ASSERT_FLOAT_EQ(float(a), float(b))
 //#define ASSERT_BF16_EQ(a, b) ASSERT_FLOAT_EQ(float(a), float(b))
-#if defined(__HIP_PLATFORM_HCC__)
+#if defined(__HIP_PLATFORM_AMD__)
 #define ASSERT_HALF_EQ(a, b)                                                         \
     do                                                                               \
     {                                                                                \

--- a/clients/samples/CMakeLists.txt
+++ b/clients/samples/CMakeLists.txt
@@ -60,7 +60,7 @@ foreach( exe ${sample_list_all} )
     target_compile_definitions( ${exe} PRIVATE ROCM_USE_FLOAT16 )
     target_link_libraries( ${exe} PRIVATE hip::host hip::device  )
   else( )
-    target_compile_definitions( ${exe} PRIVATE __HIP_PLATFORM_NVCC__ )
+    target_compile_definitions( ${exe} PRIVATE __HIP_PLATFORM_NVIDIA__ )
     target_include_directories( ${exe}
       PRIVATE
         $<BUILD_INTERFACE:${CUDA_INCLUDE_DIRS}>
@@ -70,4 +70,3 @@ foreach( exe ${sample_list_all} )
   endif( )
   rocm_install(TARGETS ${exe} COMPONENT samples)
 endforeach( )
-

--- a/clients/samples/example_compress.cpp
+++ b/clients/samples/example_compress.cpp
@@ -584,7 +584,7 @@ template <typename T>
 void initialize_a(std::vector<T>& ha, int64_t size_a)
 {
     auto CAST = [](auto x) {
-#if defined(__HIP_PLATFORM_HCC__)
+#if defined(__HIP_PLATFORM_AMD__)
         return static_cast<T>(x);
 #else
         return static_cast<T>(static_cast<float>(x));
@@ -730,7 +730,7 @@ void run(int64_t               m,
         &handle, &matD, HIPSPARSELT_MAT_BATCH_STRIDE, &stride, sizeof(stride)));
 
     auto compute_type = type == HIPSPARSELT_R_8I ? HIPSPARSELT_COMPUTE_32I :
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef __HIP_PLATFORM_AMD__
                                                  HIPSPARSELT_COMPUTE_32F;
 #else
                                                  HIPSPARSELT_COMPUTE_16F;
@@ -868,7 +868,7 @@ void run(int64_t               m,
         &hp_gold[0], &hp_compressed[0], m, n / 2, batch_count, c_stride_1, c_stride_2, c_stride_b);
 
 // cusparselt' metadata has different layout so skip metadata check.
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef __HIP_PLATFORM_AMD__
     validate_metadata(
         reinterpret_cast<unsigned char*>(&hp_gold[c_stride_b_r * batch_count_f]),
         reinterpret_cast<unsigned char*>(&hp_compressed[c_stride_b_r * batch_count_f]),

--- a/clients/samples/example_prune_strip.cpp
+++ b/clients/samples/example_prune_strip.cpp
@@ -381,7 +381,7 @@ template <typename T>
 void initialize_a(std::vector<T>& ha, int64_t size_a)
 {
     auto CAST = [](auto x) {
-#if defined(__HIP_PLATFORM_HCC__)
+#if defined(__HIP_PLATFORM_AMD__)
         return static_cast<T>(x);
 #else
         return static_cast<T>(static_cast<float>(x));
@@ -499,7 +499,7 @@ void run(int64_t               m,
         &handle, &matA, HIPSPARSELT_MAT_BATCH_STRIDE, &stride, sizeof(stride)));
 
     auto compute_type = type == HIPSPARSELT_R_8I ? HIPSPARSELT_COMPUTE_32I :
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef __HIP_PLATFORM_AMD__
                                                  HIPSPARSELT_COMPUTE_32F;
 #else
                                                  HIPSPARSELT_COMPUTE_16F;

--- a/clients/samples/example_spmm_strided_batched.cpp
+++ b/clients/samples/example_spmm_strided_batched.cpp
@@ -85,7 +85,7 @@ inline bool AlmostEqual(T a, T b)
 template <>
 inline bool AlmostEqual(__half a, __half b)
 {
-#if defined(__HIP_PLATFORM_HCC__)
+#if defined(__HIP_PLATFORM_AMD__)
     union _HALF
     {
         uint16_t x;
@@ -508,7 +508,7 @@ void initialize_a_b_c(std::vector<__half>& ha,
                       int64_t              size_c)
 {
     auto CAST = [](auto x) {
-#if defined(__HIP_PLATFORM_HCC__)
+#if defined(__HIP_PLATFORM_AMD__)
         return static_cast<__half>(x);
 #else
         return static_cast<__half>(static_cast<float>(x));
@@ -782,7 +782,7 @@ int main(int argc, char* argv[])
         &handle, &matD, HIPSPARSELT_MAT_BATCH_STRIDE, &stride_d, sizeof(stride_d)));
 
     auto compute_type =
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef __HIP_PLATFORM_AMD__
         HIPSPARSELT_COMPUTE_32F;
 #else
         HIPSPARSELT_COMPUTE_16F;

--- a/docs/.doxygen/Doxyfile
+++ b/docs/.doxygen/Doxyfile
@@ -51,7 +51,7 @@ PROJECT_BRIEF          = "prototype interfaces compatible with ROCm platform and
 # pixels and the maximum width should not exceed 200 pixels. Doxygen will copy
 # the logo to the output directory.
 
-PROJECT_LOGO           = 
+PROJECT_LOGO           =
 
 # The OUTPUT_DIRECTORY tag is used to specify the (relative or absolute) path
 # into which the generated documentation will be written. If a relative path is
@@ -2076,7 +2076,7 @@ INCLUDE_FILE_PATTERNS  =
 PREDEFINED             = __attribute__(x)= \
                          __inline= \
                          HIPSPARSELT_EXPORT= \
-                         __HIP_PLATFORM_HCC__
+                         __HIP_PLATFORM_AMD__
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -62,7 +62,7 @@ add_library(roc::hipsparselt ALIAS hipsparselt)
 # Target compile definitions
 if(NOT BUILD_CUDA)
   target_compile_options(hipsparselt PRIVATE -Wno-unused-command-line-argument -Wall)
-  target_compile_definitions(hipsparselt PRIVATE ROCM_USE_FLOAT16 __HIP_PLATFORM_HCC__)
+  target_compile_definitions(hipsparselt PRIVATE ROCM_USE_FLOAT16 __HIP_PLATFORM_AMD__)
 
   if( BUILD_WITH_TENSILE )
     if( BUILD_SHARED_LIBS )
@@ -110,7 +110,7 @@ if(NOT BUILD_CUDA)
   endif()
 
 else()
-  target_compile_definitions(hipsparselt PRIVATE __HIP_PLATFORM_NVCC__)
+  target_compile_definitions(hipsparselt PRIVATE __HIP_PLATFORM_NVIDIA__)
 endif()
 
 # Target compile features

--- a/library/include/hipsparselt.h
+++ b/library/include/hipsparselt.h
@@ -50,7 +50,7 @@
 #include <hip/hip_complex.h>
 #include <hip/hip_runtime_api.h>
 
-#if defined(__HIP_PLATFORM_HCC__)
+#if defined(__HIP_PLATFORM_AMD__)
 #include <hip/hip_bfloat16.h>
 #include <hip/hip_fp16.h>
 #include <hip/library_types.h>
@@ -62,7 +62,7 @@
 /* Opaque structures holding information */
 // clang-format off
 
-#if defined(__HIP_PLATFORM_HCC__)
+#if defined(__HIP_PLATFORM_AMD__)
 /*! \ingroup types_module
  *  \brief Handle to the hipSPARSELt library context queue.
  *
@@ -113,7 +113,7 @@ typedef struct hipsparseLtMatmulAlgSelection_t {uint8_t data[11024];} hipsparseL
  *  and \ref hipsparseLtMatmulPlanDestroy functions respectively.
  */
 typedef struct hipsparseLtMatmulPlan_t {uint8_t data[11024];} hipsparseLtMatmulPlan_t;
-#elif defined(__HIP_PLATFORM_NVCC__)
+#elif defined(__HIP_PLATFORM_NVIDIA__)
 typedef __nv_bfloat16 hip_bfloat16;
 typedef struct {uint8_t data[11024];} hipsparseLtHandle_t;
 typedef struct {uint8_t data[11024];} hipsparseLtMatDescriptor_t;


### PR DESCRIPTION
In ROCm 6.0, `__HIP_PLATFORM_HCC__` is being renamed to `__HIP_PLATFORM_AMD__`, and `__HIP_PLATFORM_NVCC__` is being renamed to `__HIP_PLATFORM_NVIDIA__`. This fix brings hipSPARSELt into alignment.