### PR TITLE
Update target name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,7 @@ if (BUILD_CUDA)
 else()
     #Set the AMDGPU_TARGETS with backward compatiblity
     rocm_check_target_ids(DEFAULT_AMDGPU_TARGETS
-        TARGETS "gfx940:xnack-;gfx940:xnack+;gfx941:xnack-;gfx941:xnack+;gfx942:xnack-;gfx942:xnack+;"
+        TARGETS "gfx940;gfx941;gfx942;"
     )
 
     if (AMDGPU_TARGETS)


### PR DESCRIPTION
pick [ec49c69](https://github.com/ROCmSoftwarePlatform/hipSPARSELt/commit/ec49c69e92dcd49cd93090e65f6b40e96b6234cf) to the release branch, to fix the mismatch with the GFX ISA list