### PR TITLE
Standardize documentation for ReadtheDocs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@
 version: 2
 updates:
   - package-ecosystem: "pip" # See documentation for possible values
-    directory: "/docs/.sphinx" # Location of package manifests
+    directory: "/docs/sphinx" # Location of package manifests
     open-pull-requests-limit: 10
     schedule:
       interval: "daily"

--- a/.gitignore
+++ b/.gitignore
@@ -38,13 +38,6 @@ tags
 
 # build-in-source directory and documentation artifacts
 build/
-_build/
-_images/
-_static/
-_templates/
-_toc.yml
-_doxygen
-docBin/
 
 # matrices
 *.csr

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,6 +13,6 @@ python:
    - requirements: docs/sphinx/requirements.txt
 
 build:
-   os: ubuntu-20.04
+   os: ubuntu-22.04
    tools:
       python: "3.8"

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,6 @@
+_build/
+_doxygen/
+doxygen/html/
+doxygen/xml/
+doxygen/*.tag
+sphinx/_toc.yml

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,12 +4,26 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+import re
+
 from rocm_docs import ROCmDocs
 
-external_projects_current_project = "hipsparselt"
+with open('../CMakeLists.txt', encoding='utf-8') as f:
+    match = re.search(r'.*\bset \(VERSION_STRING\s+\"?([0-9.]+)[^0-9.]+', f.read())
+    if not match:
+        raise ValueError("VERSION not found!")
+    version_number = match[1]
+left_nav_title = f"hipSPARSELt {version_number} Documentation"
 
-docs_core = ROCmDocs("hipSPARSELt Documentation")
-docs_core.run_doxygen(doxygen_root="doxygen", doxygen_path="doxygen/docBin/xml")
+# for PDF output on Read the Docs
+project = "hipSPARSELt Documentation"
+author = "Advanced Micro Devices, Inc."
+copyright = "Copyright (c) 2024 Advanced Micro Devices, Inc. All rights reserved."
+version = version_number
+release = version_number
+
+docs_core = ROCmDocs(left_nav_title)
+docs_core.run_doxygen(doxygen_root="doxygen", doxygen_path="doxygen/xml")
 docs_core.enable_api_reference()
 docs_core.setup()
 
@@ -18,6 +32,8 @@ extensions = ['sphinx_design', 'sphinx.ext.intersphinx']
 exclude_patterns = ['reference/api-library.md']
 
 external_toc_path = "./sphinx/_toc.yml"
+
+external_projects_current_project = "hipsparselt"
 
 suppress_warnings = ["etoc.toctree"]
 

--- a/docs/doxygen/Doxyfile
+++ b/docs/doxygen/Doxyfile
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = docBin
+OUTPUT_DIRECTORY       = .
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and
@@ -2239,7 +2239,7 @@ TAGFILES               =
 # tag file that is based on the input files it reads. See section "Linking to
 # external documentation" for more information about the usage of tag files.
 
-GENERATE_TAGFILE       = docBin/html/tagfile.xml
+GENERATE_TAGFILE       = html/tagfile.xml
 
 # If the ALLEXTERNALS tag is set to YES, all external class will be listed in
 # the class index. If set to NO, only the inherited external classes will be

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,7 +19,7 @@ Our documentation is structured as follows:
   * :ref:`device-stream-manage`
   * :ref:`storage-format`
   * :ref:`porting`
-  * :doc:`API library <../doxygen/docBin/html/index>`
+  * :doc:`API library <../doxygen/html/index>`
 
 .. card:: :ref:`tutorials-index`
 

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -1,0 +1,4 @@
+License
+=======
+
+.. include:: ../LICENSE.md

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -29,4 +29,4 @@ The API reference guide is organized into the following sections:
 * :ref:`device-stream-manage`
 * :ref:`storage-format`
 * :ref:`porting`
-* :doc:`API library <../doxygen/docBin/html/index>`
+* :doc:`API library <../doxygen/html/index>`

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -24,7 +24,7 @@ subtrees:
         title: Storage formats
       - file: reference/porting.rst
         title: Porting from CUDA
-      - file: doxygen/docBin/html/index
+      - file: doxygen/html/index
         title: API library
 
   - file: tutorials/index.rst
@@ -33,3 +33,7 @@ subtrees:
     - entries:
       - file: tutorials/install/linux.rst
         title: Installing and building hipSPARSELt for Linux
+
+- caption: About
+  entries:
+  - file: license

--- a/docs/sphinx/requirements.in
+++ b/docs/sphinx/requirements.in
@@ -1,1 +1,1 @@
-rocm-docs-core[api_reference]>=0.24.0
+rocm-docs-core[api_reference]==0.30.3

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -53,6 +53,10 @@ idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
+importlib-metadata==7.0.1
+    # via sphinx
+importlib-resources==6.1.1
+    # via rocm-docs-core
 jinja2==3.1.2
     # via
     #   myst-parser
@@ -101,6 +105,8 @@ pynacl==1.5.0
     # via pygithub
 pyparsing==3.1.1
     # via doxysphinx
+pytz==2023.3.post1
+    # via babel
 pyyaml==6.0
     # via
     #   myst-parser
@@ -110,7 +116,7 @@ requests==2.28.2
     # via
     #   pygithub
     #   sphinx
-rocm-docs-core[api_reference]>=0.24.0
+rocm-docs-core[api_reference]==0.30.3
     # via -r requirements.in
 smmap==5.0.0
     # via gitdb
@@ -139,7 +145,6 @@ sphinx-external-toc==0.3.1
     # via rocm-docs-core
 sphinx-notfound-page==0.8.3
     # via rocm-docs-core
-sphinx-tabs
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
@@ -160,3 +165,7 @@ urllib3==1.26.15
     # via requests
 wrapt==1.15.0
     # via deprecated
+zipp==3.17.0
+    # via
+    #   importlib-metadata
+    #   importlib-resources


### PR DESCRIPTION
Apply the following changes to project documentation for ReadtheDocs:

add version number to documentation left navigation bar and page title
add an "About" section with a license page
enable htmlzip, pdf, epub formats when publishing on Read the Docs
set pdf title, author, copyright, and version
rename .sphinx/.doxygen to sphinx/doxygen
remove docBin from URL
update rocm-docs-core dependency
update dependabot config

Relates to https://github.com/RadeonOpenCompute/rocm-docs-core/issues/330