### PR TITLE
Removing HIPSPARSELT_COMPUTE_16F, HIPSPARSELT_COMPUTE_TF32 and HIPSPARSELT_COMPUTE_TF32_FAST emulators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,20 @@
 # Change Log for hipSPARSELt
 
+## (Unreleased) hipSPARSELt 0.3.0
+
+### Additions
+
+* For aligning cuda-backend with cuSPARSELt v0.5.2, HIPSPARSELT_COMPUTE_16F, HIPSPARSELT_COMPUTE_TF32 and HIPSPARSELT_COMPUTE_TF32_FAST enumerators
+  have been removed for the hipsparseLtComputetype_t enumerator and replaced with HIPSPARSELT_COMPUTE_32F.
+  Note: For hip-backend, which didn't support above 3 compute types. Hence, this change doesn't impact the behavior for the hip-backend.
+
 ## (Unreleased) hipSPARSELt 0.2.0
 
 ### Additions
 
 * Support Matrix B is a Structured Sparsity Matrix.
 
-## (Unreleased) hipSPARSELt 0.1.0
+## hipSPARSELt 0.1.0
 
 ### Additions
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,9 +221,9 @@ get_os_id(OS_ID)
 message (STATUS "OS detected is ${OS_ID}")
 
 # Setup version
-set (VERSION_STRING "0.1.0" )
+set (VERSION_STRING "0.3.0" )
 rocm_setup_version( VERSION ${VERSION_STRING} )
-set(hipsparselt_SOVERSION 0.1)
+set(hipsparselt_SOVERSION 0.3)
 
 # setup rocsparselt defines used for both the library and clients
 if( BUILD_WITH_TENSILE )

--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (c) 2022-2023 Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2024 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -90,14 +90,8 @@ struct perf_sparse<
     Tc,
     TBias,
     std::enable_if_t<
-#ifdef __HIP_PLATFORM_AMD__
         (std::is_same<Ti, To>{} && (std::is_same<Ti, __half>{} || std::is_same<Ti, hip_bfloat16>{})
          && std::is_same<Tc, float>{})
-#else
-        (std::is_same<Ti, To>{}
-         && ((std::is_same<Ti, __half>{} && std::is_same<Tc, __half>{})
-             || (std::is_same<Ti, hip_bfloat16>{} && std::is_same<Tc, hip_bfloat16>{})))
-#endif
         || (std::is_same<Ti, To>{} && (std::is_same<Ti, int8_t>{}) && std::is_same<Tc, int32_t>{})
         || (std::is_same<Ti, int8_t>{} && (std::is_same<To, __half>{})
             && std::is_same<Tc, int32_t>{})>> : hipsparselt_test_valid
@@ -534,8 +528,7 @@ try
 #ifdef __HIP_PLATFORM_AMD__
                            ? (is_f16 ? HIPSPARSELT_COMPUTE_32F : HIPSPARSELT_COMPUTE_32I)
 #else
-                           ? (is_f16   ? HIPSPARSELT_COMPUTE_16F
-                              : is_f32 ? HIPSPARSELT_COMPUTE_TF32
+                           ? (is_f16  || is_f32 ? HIPSPARSELT_COMPUTE_32F
                                        : HIPSPARSELT_COMPUTE_32I)
 #endif
                            : string_to_hipsparselt_computetype(compute_type);

--- a/clients/include/hipsparselt_common.yaml
+++ b/clients/include/hipsparselt_common.yaml
@@ -12,9 +12,8 @@ Datatypes:
   - hipsparseLtComputetype_t:
       bases: [ c_int ]
       attr:
-        c_f16_r: 0
-        c_i32_r: 1
-        c_f32_r: 2
+        c_i32_r: 0
+        c_f32_r: 1
   - { half: f16_r }
   - hipsparselt_initialization:
       bases: [ c_int ]

--- a/clients/include/testing_auxiliary.hpp
+++ b/clients/include/testing_auxiliary.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (c) 2022-2023 Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2024 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -601,11 +601,7 @@ void testing_aux_matmul_init_bad_arg(const Arguments& arg)
         tmpComputeType = HIPSPARSELT_COMPUTE_32I;
         break;
     default:
-#ifdef __HIP_PLATFORM_AMD__
         tmpComputeType = HIPSPARSELT_COMPUTE_32F;
-#else
-        tmpComputeType = HIPSPARSELT_COMPUTE_16F;
-#endif
         break;
     }
     EXPECT_HIPSPARSE_STATUS(hipsparseLtMatmulDescriptorInit(

--- a/clients/include/type_dispatch.hpp
+++ b/clients/include/type_dispatch.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (c) 2022-2023 Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2024 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -105,16 +105,6 @@ auto hipsparselt_spmm_dispatch(const Arguments& arg)
             default:
                 break;
             }
-        }
-        if(Ti == To && To == HIPSPARSELT_R_16F && Tc == HIPSPARSELT_COMPUTE_16F
-           && TBias == HIPSPARSELT_R_16F)
-        {
-            return TEST<__half, __half, __half, __half>{}(arg);
-        }
-        else if(Ti == To && To == HIPSPARSELT_R_16BF && Tc == HIPSPARSELT_COMPUTE_16F
-                && TBias == HIPSPARSELT_R_16BF)
-        {
-            return TEST<hip_bfloat16, hip_bfloat16, hip_bfloat16, hip_bfloat16>{}(arg);
         }
         else if(Ti == To && To == HIPSPARSELT_R_8I && Tc == HIPSPARSELT_COMPUTE_32I
                 && TBias == HIPSPARSELT_R_32F)

--- a/clients/samples/example_compress.cpp
+++ b/clients/samples/example_compress.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (c) 2022-2023 Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2024 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -771,12 +771,8 @@ void run(int64_t               m,
     CHECK_HIPSPARSELT_ERROR(hipsparseLtMatDescSetAttribute(
         &handle, sparse_b? &matB : &matA, HIPSPARSELT_MAT_BATCH_STRIDE, &stride, sizeof(stride)));
 
-    auto compute_type = type == HIPSPARSELT_R_8I ? HIPSPARSELT_COMPUTE_32I :
-#ifdef __HIP_PLATFORM_AMD__
-                                                 HIPSPARSELT_COMPUTE_32F;
-#else
-                                                 HIPSPARSELT_COMPUTE_16F;
-#endif
+    auto compute_type = type == HIPSPARSELT_R_8I ? HIPSPARSELT_COMPUTE_32I : HIPSPARSELT_COMPUTE_32F;
+
 
     CHECK_HIPSPARSELT_ERROR(hipsparseLtMatmulDescriptorInit(&handle,
                                                             &matmul,

--- a/clients/samples/example_prune_strip.cpp
+++ b/clients/samples/example_prune_strip.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (c) 2022-2023 Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2024 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -529,12 +529,7 @@ void run(int64_t               m,
     CHECK_HIPSPARSELT_ERROR(hipsparseLtMatDescSetAttribute(
         &handle, sparse_b? &matB : &matA, HIPSPARSELT_MAT_BATCH_STRIDE, &stride, sizeof(stride)));
 
-    auto compute_type = type == HIPSPARSELT_R_8I ? HIPSPARSELT_COMPUTE_32I :
-#ifdef __HIP_PLATFORM_AMD__
-                                                 HIPSPARSELT_COMPUTE_32F;
-#else
-                                                 HIPSPARSELT_COMPUTE_16F;
-#endif
+    auto compute_type = type == HIPSPARSELT_R_8I ? HIPSPARSELT_COMPUTE_32I : HIPSPARSELT_COMPUTE_32F;
 
     CHECK_HIPSPARSELT_ERROR(hipsparseLtMatmulDescriptorInit(&handle,
                                                             &matmul,

--- a/clients/samples/example_spmm_strided_batched.cpp
+++ b/clients/samples/example_spmm_strided_batched.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (c) 2022-2023 Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2024 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -808,12 +808,7 @@ int main(int argc, char* argv[])
     CHECK_HIPSPARSELT_ERROR(hipsparseLtMatDescSetAttribute(
         &handle, &matD, HIPSPARSELT_MAT_BATCH_STRIDE, &stride_d, sizeof(stride_d)));
 
-    auto compute_type =
-#ifdef __HIP_PLATFORM_AMD__
-        HIPSPARSELT_COMPUTE_32F;
-#else
-        HIPSPARSELT_COMPUTE_16F;
-#endif
+    auto compute_type = HIPSPARSELT_COMPUTE_32F;
 
     CHECK_HIPSPARSELT_ERROR(hipsparseLtMatmulDescriptorInit(
         &handle, &matmul, trans_a, trans_b, &matA, &matB, &matC, &matD, compute_type));

--- a/docs/reference/data-type-support.rst
+++ b/docs/reference/data-type-support.rst
@@ -45,7 +45,7 @@ Data type support
       - ✅
       - ✅
     *
-      - bfloat16      
+      - bfloat16
       - HIPSPARSELT_R_16BF
       - ✅
       - ✅
@@ -105,7 +105,7 @@ Data type support
       - float16
       - HIPSPARSELT_COMPUTE_16F
       - ❌
-      - ✅
+      - ❌
     *
       - bfloat16
       - Not Supported
@@ -120,28 +120,24 @@ Data type support
       - tensorfloat32
       - Not Supported
       - ❌
-      - ✅
+      - ❌
     *
       - float32
       - HIPSPARSELT_COMPUTE_32F
       - ✅
-      - ❌
+      - ✅
     *
       - float64
       - Not Supported
       - ❌
-      - ❌      
+      - ❌
 
 * List of supported compute types at specific input and output types:
 
   .. csv-table::
      :header: "Input", "Output", "Compute type", "Backend"
 
-     "HIPSPARSELT_R_16F", "HIPSPARSELT_R_16F", "HIPSPARSELT_COMPUTE_32F", "HIP"
-     "HIPSPARSELT_R_16BF", "HIPSPARSELT_R_16BF", "HIPSPARSELT_COMPUTE_32F", "HIP"
+     "HIPSPARSELT_R_16F", "HIPSPARSELT_R_16F", "HIPSPARSELT_COMPUTE_32F", "HIP / CUDA"
+     "HIPSPARSELT_R_16BF", "HIPSPARSELT_R_16BF", "HIPSPARSELT_COMPUTE_32F", "HIP / CUDA"
      "HIPSPARSELT_R_8I", "HIPSPARSELT_R_8I", "HIPSPARSELT_COMPUTE_32I", "HIP / CUDA"
      "HIPSPARSELT_R_8I", "HIPSPARSELT_R_16F", "HIPSPARSELT_COMPUTE_32I", "HIP / CUDA"
-     "HIPSPARSELT_R_16F", "HIPSPARSELT_R_16F", "HIPSPARSELT_COMPUTE_16F", "CUDA"
-     "HIPSPARSELT_R_16BF", "HIPSPARSELT_R_16BF", "HIPSPARSELT_COMPUTE_16F", "CUDA"
-     "HIPSPARSELT_R_32F", "HIPSPARSELT_R_32F", "HIPSPARSELT_COMPUTE_TF32", "CUDA"
-     "HIPSPARSELT_R_32F", "HIPSPARSELT_R_32F", "HIPSPARSELT_COMPUTE_TF32_FAST", "CUDA"

--- a/library/include/hipsparselt.h
+++ b/library/include/hipsparselt.h
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (c) 2022-2023 Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2024 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -60,7 +60,7 @@
  *
  *  \defgroup helper_module Helper functions
  *  Required for subsequent library calls
- * 
+ *
  *  \defgroup aux_module Auxilary functions
  *  Initializes hipSPARSELt for the current HIP device
  */
@@ -198,13 +198,8 @@ typedef enum {
  *  \details
  */
 typedef enum {
-   HIPSPARSELT_COMPUTE_16F = 0,     /**< 16-bit floating-point precision. CUDA backend only. */
-   HIPSPARSELT_COMPUTE_32I,         /**< 32-bit integer precision */
+   HIPSPARSELT_COMPUTE_32I = 0,     /**< 32-bit integer precision */
    HIPSPARSELT_COMPUTE_32F,         /**< 32-bit floating-point precision. HIP backend only. */
-   HIPSPARSELT_COMPUTE_TF32,        /**< 32-bit floating point value are rounded to TF32 before the computation.
-                                       CUDA backend only. */
-   HIPSPARSELT_COMPUTE_TF32_FAST    /**< 32-bit floating point value are truncated to TF32 before the computation.
-                                       CUDA backend only. */
 } hipsparseLtComputetype_t;
 
 /*! \ingroup types_module

--- a/library/src/auxiliary.cpp
+++ b/library/src/auxiliary.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2022-2023 Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2024 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -41,9 +41,6 @@ const hipsparseLtComputetype_t string_to_hipsparselt_computetype(const std::stri
     return
         value == "f32_r" || value == "s" ? HIPSPARSELT_COMPUTE_32F  :
         value == "i32_r"                 ? HIPSPARSELT_COMPUTE_32I  :
-        value == "f16_r" || value == "h" ? HIPSPARSELT_COMPUTE_16F  :
-        value == "tf32_r"                ? HIPSPARSELT_COMPUTE_TF32  :
-        value == "tf32f_r"               ? HIPSPARSELT_COMPUTE_TF32_FAST  :
         static_cast<hipsparseLtComputetype_t>(-1);
 }
 // clang-format on

--- a/library/src/include/auxiliary.hpp
+++ b/library/src/include/auxiliary.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (c) 2022-2023 Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2024 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -119,16 +119,10 @@ constexpr const char* hipsparselt_computetype_to_string(hipsparseLtComputetype_t
 {
     switch(type)
     {
-    case HIPSPARSELT_COMPUTE_16F:
-        return "f16_r";
     case HIPSPARSELT_COMPUTE_32I:
         return "i32_r";
     case HIPSPARSELT_COMPUTE_32F:
         return "f32_r";
-    case HIPSPARSELT_COMPUTE_TF32:
-        return "tf32_r";
-    case HIPSPARSELT_COMPUTE_TF32_FAST:
-        return "tf32f_r";
     }
     return "invalid";
 }

--- a/library/src/nvcc_detail/hipsparselt.cpp
+++ b/library/src/nvcc_detail/hipsparselt.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (c) 2022-2023 Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2024 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,6 +25,7 @@
  *******************************************************************************/
 
 #include "exceptions.hpp"
+#include <string>
 #include <hipsparselt/hipsparselt.h>
 
 #include <cusparseLt.h>
@@ -159,14 +160,10 @@ cusparseComputeType HIPComputetypeToCuSparseComputetype(hipsparseLtComputetype_t
 {
     switch(type)
     {
-    case HIPSPARSELT_COMPUTE_16F:
-        return CUSPARSE_COMPUTE_16F;
+    case HIPSPARSELT_COMPUTE_32F:
+        return CUSPARSE_COMPUTE_32F;
     case HIPSPARSELT_COMPUTE_32I:
         return CUSPARSE_COMPUTE_32I;
-    case HIPSPARSELT_COMPUTE_TF32:
-        return CUSPARSE_COMPUTE_TF32;
-    case HIPSPARSELT_COMPUTE_TF32_FAST:
-        return CUSPARSE_COMPUTE_TF32_FAST;
     default:
         throw HIPSPARSE_STATUS_NOT_SUPPORTED;
     }
@@ -176,14 +173,10 @@ hipsparseLtComputetype_t CuSparseLtComputetypeToHIPComputetype(cusparseComputeTy
 {
     switch(type)
     {
-    case CUSPARSE_COMPUTE_16F:
-        return HIPSPARSELT_COMPUTE_16F;
+    case CUSPARSE_COMPUTE_32F:
+        return HIPSPARSELT_COMPUTE_32F;
     case CUSPARSE_COMPUTE_32I:
         return HIPSPARSELT_COMPUTE_32I;
-    case CUSPARSE_COMPUTE_TF32:
-        return HIPSPARSELT_COMPUTE_TF32;
-    case CUSPARSE_COMPUTE_TF32_FAST:
-        return HIPSPARSELT_COMPUTE_TF32_FAST;
     default:
         throw HIPSPARSE_STATUS_NOT_SUPPORTED;
     }


### PR DESCRIPTION
For aligning cuda-backend with cuSPARSELt v0.5.2, remove HIPSPARSELT_COMPUTE_16F, HIPSPARSELT_COMPUTE_TF32 and HIPSPARSELT_COMPUTE_TF32_FAST.