### PR TITLE
[HotFix]update hipsparselt version to v0.2.0 for 6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Support Matrix B is a Structured Sparsity Matrix.
 
-## (Unreleased) hipSPARSELt 0.1.0
+## hipSPARSELt 0.1.0
 
 ### Added
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,9 +217,9 @@ get_os_id(OS_ID)
 message (STATUS "OS detected is ${OS_ID}")
 
 # Setup version
-set (VERSION_STRING "0.1.0" )
+set (VERSION_STRING "0.2.0" )
 rocm_setup_version( VERSION ${VERSION_STRING} )
-set(hipsparselt_SOVERSION 0.1)
+set(hipsparselt_SOVERSION 0.2)
 
 # setup rocsparselt defines used for both the library and clients
 if( BUILD_WITH_TENSILE )


### PR DESCRIPTION
update hipsparselt version to v0.2.0
https://ontrack-internal.amd.com/browse/SWDEV-456729