### PR TITLE
Update documentation - license and link fixes and codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,8 @@
 * @vin-huang @jichangjichang @hcman2 @imcarsonliao
 # Documentation files
-docs/* @ROCm/rocm-documentation
+docs/ @ROCm/rocm-documentation
 *.md @ROCm/rocm-documentation
 *.rst @ROCm/rocm-documentation
+.readthedocs.yaml @ROCm/rocm-documentation
 # Header directory for Doxygen documentation
-library/include/* @ROCm/rocm-documentation
+library/include/ @ROCm/rocm-documentation @vin-huang @jichangjichang @hcman2 @imcarsonliao

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,3 @@
-
 Copyright (c) 2022-2024 Advanced Micro Devices, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:

--- a/docs/license.md
+++ b/docs/license.md
@@ -1,4 +1,3 @@
-# License
-
+<!-- markdownlint-disable first-line-h1 -->
 ```{include} ../LICENSE.md
 ```

--- a/docs/tutorials/quick-start/linux.rst
+++ b/docs/tutorials/quick-start/linux.rst
@@ -9,7 +9,7 @@ Quick-start installation (Ubuntu)
 ****************************************************************
 
 The root of the
-`hipSPARSELt GitHub repository <https://github.com/ROCmSoftwarePlatform/hipSPARSELt>`_ has a
+`hipSPARSELt GitHub repository <https://github.com/ROCm/hipSPARSELt>`_ has a
 helper bash script `install.sh` to build and install hipSPARSELt on Ubuntu with a single command. It
 doesn't take a lot of options and hard-codes configuration that can be specified through invoking
 CMake directly, but it's a great way to get started quickly and can serve as an example of how to build

--- a/docs/what-is-hipsparselt.rst
+++ b/docs/what-is-hipsparselt.rst
@@ -19,5 +19,5 @@ programming language and is optimized for AMD's latest discrete GPUs.
 hipSPARSELt sits between the application and a 'worker' SPARSE library, marshalling inputs into the
 backend library and marshalling results back to the application. It exports an interface that doesn't
 require the client to change, regardless of the chosen backend. Current supported backends are:
-`rocSPARSELt <https://github.com/ROCmSoftwarePlatform/hipSPARSELt/blob/develop/library/src/hcc_detail/rocsparselt>`_
+`rocSPARSELt <https://github.com/ROCm/hipSPARSELt/tree/develop/library/src/hcc_detail/rocsparselt>`_
 and `cuSPARSELt v0.4 <https://docs.nvidia.com/cuda/cusparselt>`_.


### PR DESCRIPTION
Changes:
[Remove duplicate header in doc license](https://github.com/ROCm/hipSPARSELt/commit/90017d45908ca184818875f0470e356770712dbd)
[Fix org in GitHub links](https://github.com/ROCm/hipSPARSELt/commit/93dd2ebcd4975cd5628136cf73da343a2b2023c9)

Also set doc team as codeowners for .readthedocs.yaml