### PR TITLE
Fix issues in hipsparselt library

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -92,6 +92,9 @@ if(NOT BUILD_CUDA)
     # Tensile host depends on libs build target
     add_dependencies( TensileHost TENSILE_LIBRARY_TARGET )
 
+    set_target_properties( TensileHost PROPERTIES CXX_VISIBILITY_PRESET hidden)
+    set_target_properties( TensileHost PROPERTIES C_VISIBILITY_PRESET hidden)
+
     if( ROCSPARSELT_SHARED_LIBS )
       set( BUILD_SHARED_LIBS ON )
       set_target_properties( TensileHost PROPERTIES POSITION_INDEPENDENT_CODE ON )

--- a/library/src/hcc_detail/rocsparselt/src/include/rocsparselt_spmm_utils.hpp
+++ b/library/src/hcc_detail/rocsparselt/src/include/rocsparselt_spmm_utils.hpp
@@ -61,6 +61,40 @@ inline rocsparselt_status getOriginalSizes(rocsparselt_operation opA,
     return rocsparselt_status_success;
 }
 
+inline void initSparseMatrixLayout(rocsparselt_operation          op,
+                                    const rocsparselt_mat_descr*  sparseMatDescr,
+                                    bool                          isSparseA)
+
+{
+    auto _sparseMatDescr = reinterpret_cast<_rocsparselt_mat_descr*>(
+        const_cast<rocsparselt_mat_descr*>(sparseMatDescr));
+    if(isSparseA)
+    {
+        auto m = _sparseMatDescr->m;
+        auto k = _sparseMatDescr->n;
+        if (op == rocsparselt_operation_transpose)
+            std::swap(m, k);
+        _sparseMatDescr->c_k  = k / 2;
+        _sparseMatDescr->c_ld = m;
+        _sparseMatDescr->c_n  = _sparseMatDescr->c_k;
+        if((op == rocsparselt_operation_transpose)
+           != (_sparseMatDescr->order == rocsparselt_order_row))
+            std::swap(_sparseMatDescr->c_ld, _sparseMatDescr->c_n);
+    }
+    else
+    {
+        auto k = _sparseMatDescr->m;
+        auto n = _sparseMatDescr->n;
+        if (op == rocsparselt_operation_transpose)
+            std::swap(n, k);
+        _sparseMatDescr->c_k  = k / 2;
+        _sparseMatDescr->c_ld = _sparseMatDescr->c_k;
+        _sparseMatDescr->c_n  = n;
+        if((op == rocsparselt_operation_transpose)
+           != (_sparseMatDescr->order == rocsparselt_order_row))
+            std::swap(_sparseMatDescr->c_ld, _sparseMatDescr->c_n);
+    }
+}
 /*******************************************************************************
  * Get the offset of the metatdata (in bytes)
  ******************************************************************************/

--- a/library/src/hcc_detail/rocsparselt/src/spmm/rocsparselt_compress.cpp
+++ b/library/src/hcc_detail/rocsparselt/src/spmm/rocsparselt_compress.cpp
@@ -644,6 +644,8 @@ rocsparselt_status rocsparselt_smfmac_compress2(const rocsparselt_handle*    han
         return rocsparselt_status_not_implemented;
     }
 
+    initSparseMatrixLayout(op, sparseMatDescr, isSparseA);
+
     log_api(_handle,
             __func__,
             "sparseMatDescr[in]",

--- a/library/src/hcc_detail/rocsparselt/src/spmm/rocsparselt_prune.cpp
+++ b/library/src/hcc_detail/rocsparselt/src/spmm/rocsparselt_prune.cpp
@@ -29,6 +29,7 @@
 #include "rocsparselt.h"
 #include "status.h"
 #include "utility.hpp"
+#include "rocsparselt_spmm_utils.hpp"
 
 #include "hipsparselt_ostream.hpp"
 #include <hip/hip_runtime_api.h>
@@ -805,6 +806,8 @@ rocsparselt_status rocsparselt_smfmac_prune2(const rocsparselt_handle*    handle
         return rocsparselt_status_not_implemented;
     }
 
+    initSparseMatrixLayout(op, sparseMatDescr, isSparseA);
+
     log_api(_handle,
             __func__,
             "sparseMatDescr[in]",
@@ -960,6 +963,8 @@ rocsparselt_status rocsparselt_smfmac_prune_check2(const rocsparselt_handle*    
         log_error(_handle, __func__, "Matrix is not a structured matrix");
         return rocsparselt_status_not_implemented;
     }
+
+    initSparseMatrixLayout(op, sparseMatDescr, isSparseA);
 
     log_api(_handle,
             __func__,

--- a/tensilelite_tag.txt
+++ b/tensilelite_tag.txt
@@ -1,1 +1,1 @@
-02e042a5b6e425d6c1edf14618acd0a2d103beed
+292c1d0dac97ab3e5cbecb8107fec0d3f8addb10

--- a/tensilelite_tag.txt
+++ b/tensilelite_tag.txt
@@ -1,1 +1,1 @@
-292c1d0dac97ab3e5cbecb8107fec0d3f8addb10
+02e042a5b6e425d6c1edf14618acd0a2d103beed


### PR DESCRIPTION
1. An additional patch for [PR144](https://github.com/ROCm/hipSPARSELt/pull/144)
2. Initialized information of compressed matrix's row, col and ld when using prune2, compress2 related functions directly.
([SWDEV-483037](https://ontrack-internal.amd.com/browse/SWDEV-483037))