### PR TITLE
Correct hipsparseLtGetProperty function name

### DIFF
--- a/library/src/hcc_detail/hipsparselt.cpp
+++ b/library/src/hcc_detail/hipsparselt.cpp
@@ -1005,7 +1005,7 @@ catch(...)
     return exception_to_hipsparselt_status();
 }
 
-hipsparseStatus_t hipsparseLtGetPorperty(hipLibraryPropertyType propertyType, int* value)
+hipsparseStatus_t hipsparseLtGetProperty(hipLibraryPropertyType propertyType, int* value)
 try
 {
     switch(propertyType)


### PR DESCRIPTION
Fix for https://github.com/ROCm/hipSPARSELt/issues/157.

Correct typo from `hipsparseLtGetPorperty` to `hipsparseLtGetProperty` in library/src/hcc_detail/hipsparselt.cpp.