### PR TITLE
Correct hipsparseLtGetProperty function name (Sync from PR162)

### DIFF
--- a/library/src/hcc_detail/hipsparselt.cpp
+++ b/library/src/hcc_detail/hipsparselt.cpp
@@ -1005,7 +1005,7 @@ catch(...)
     return exception_to_hipsparselt_status();
 }
 
-hipsparseStatus_t hipsparseLtGetPorperty(hipLibraryPropertyType propertyType, int* value)
+hipsparseStatus_t hipsparseLtGetProperty(hipLibraryPropertyType propertyType, int* value)
 try
 {
     switch(propertyType)


### PR DESCRIPTION
Sync from [PR162](https://github.com/ROCm/hipSPARSELt/pull/162)