### PR TITLE
Fix alpha not in host memory

### DIFF
--- a/library/src/hcc_detail/rocsparselt/src/tensile_host.cpp
+++ b/library/src/hcc_detail/rocsparselt/src/tensile_host.cpp
@@ -197,7 +197,7 @@ namespace
         // We set K=0 when alpha==0.
         // This makes alpha==0 a change in the problem, and not just a change in the inputs.
         // It optimizes all problems with alpha==0 into K=0 and alpha=(don't care)
-        auto k = prob.k && *prob.alpha ? prob.k : 0;
+        auto k = prob.k && (prob.alpha_vector_scaling || *prob.alpha) ? prob.k : 0;
 
         // clang-format off
 


### PR DESCRIPTION
[----------] Global test environment tear-down
[==========] 105252 tests from 4 test suites ran. (6268931 ms total)
[  PASSED  ] 105252 tests.
hipSPARSELt version: 202
