### PR TITLE
add include directories for hipSPARSE and rocTracer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,6 +243,7 @@ get_os_id(OS_ID)
 message (STATUS "OS detected is ${OS_ID}")
 
 if(HIPSPARSELT_ENABLE_MARKER)
+  find_path(ROCTRACER_INCLUDE_DIR "roctracer/roctx.h")
   find_library(rocTracer roctx64 PATHS ${ROCM_PATH}/lib)
   if(NOT rocTracer)
     message(FATAL_ERROR "roctracer not found, but HIPSPARSELT_ENABLE_MARKER is enabled")

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -123,6 +123,7 @@ target_include_directories(hipsparselt
                            PUBLIC  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/library/include>
                                    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
                                    $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>
+                                   $<BUILD_INTERFACE:${HIPSPARSE_INCLUDE_DIRS}>
                                    $<INSTALL_INTERFACE:include>
 )
 
@@ -147,7 +148,8 @@ else()
 endif()
 
 if(HIPSPARSELT_ENABLE_MARKER)
-  target_link_libraries(hipsparselt PRIVATE -lroctx64)
+  target_include_directories(hipsparselt PRIVATE ${ROCTRACER_INCLUDE_DIR})
+  target_link_libraries(hipsparselt PRIVATE ${rocTracer})
 endif()
 
 # Target properties


### PR DESCRIPTION
This PR resolves issues related to building hipSPARSELt with [spack](https://github.com/spack/spack). In Spack, all of these packages are installed in different paths, not is a single /opt/rocm path, which is why the include directories for hipSPARSE and rocTracer need to be explictly added.