### PR TITLE
Remove unused internal helper functions.

### DIFF
--- a/library/src/hcc_detail/hipsparselt.cpp
+++ b/library/src/hcc_detail/hipsparselt.cpp
@@ -99,19 +99,6 @@ rocsparselt_compute_type_ HIPComputetypeToRocSparseLtComputetype(hipsparseLtComp
     }
 }
 
-hipsparseLtComputetype_t RocSparseLtComputetypeToHIPComputetype(rocsparselt_compute_type_ type)
-{
-    switch(type)
-    {
-    case rocsparselt_compute_f32:
-        return HIPSPARSELT_COMPUTE_32F;
-
-    case rocsparselt_compute_i32:
-        return HIPSPARSELT_COMPUTE_32I;
-    }
-    throw HIPSPARSE_STATUS_NOT_SUPPORTED;
-}
-
 rocsparselt_operation_ HIPOperationToHCCOperation(hipsparseOperation_t op)
 {
     switch(op)
@@ -155,36 +142,12 @@ rocsparselt_order_ HIPOrderToHCCOrder(hipsparseOrder_t op)
     }
 }
 
-hipsparseOrder_t HCCOrderToHIPOrder(rocsparselt_order_ op)
-{
-    switch(op)
-    {
-    case rocsparselt_order_row:
-        return HIPSPARSE_ORDER_ROW;
-    case rocsparselt_order_column:
-        return HIPSPARSE_ORDER_COL;
-    default:
-        throw HIPSPARSE_STATUS_NOT_SUPPORTED;
-    }
-}
-
 rocsparselt_sparsity_ HIPSparsityToRocSparseLtSparsity(hipsparseLtSparsity_t sparsity)
 {
     switch(sparsity)
     {
     case HIPSPARSELT_SPARSITY_50_PERCENT:
         return rocsparselt_sparsity_50_percent;
-    default:
-        throw HIPSPARSE_STATUS_NOT_SUPPORTED;
-    }
-}
-
-hipsparseLtSparsity_t RocSparseLtSparsityToHIPSparsity(rocsparselt_sparsity_ sparsity)
-{
-    switch(sparsity)
-    {
-    case rocsparselt_sparsity_50_percent:
-        return HIPSPARSELT_SPARSITY_50_PERCENT;
     default:
         throw HIPSPARSE_STATUS_NOT_SUPPORTED;
     }
@@ -234,63 +197,6 @@ rocsparselt_matmul_descr_attribute_
     }
 }
 
-hipsparseLtMatmulDescAttribute_t
-    RocSparseLtMatmulDescAttributeToHIPMatmulDescAttribute(rocsparselt_matmul_descr_attribute_ attr)
-{
-    switch(attr)
-    {
-    case rocsparselt_matmul_activation_relu:
-        return HIPSPARSELT_MATMUL_ACTIVATION_RELU;
-    case rocsparselt_matmul_activation_relu_upperbound:
-        return HIPSPARSELT_MATMUL_ACTIVATION_RELU_UPPERBOUND;
-    case rocsparselt_matmul_activation_relu_threshold:
-        return HIPSPARSELT_MATMUL_ACTIVATION_RELU_THRESHOLD;
-    case rocsparselt_matmul_activation_gelu:
-        return HIPSPARSELT_MATMUL_ACTIVATION_GELU;
-    case rocsparselt_matmul_activation_gelu_scaling:
-        return HIPSPARSELT_MATMUL_ACTIVATION_GELU_SCALING;
-    case rocsparselt_matmul_alpha_vector_scaling:
-        return HIPSPARSELT_MATMUL_ALPHA_VECTOR_SCALING;
-    case rocsparselt_matmul_beta_vector_scaling:
-        return HIPSPARSELT_MATMUL_BETA_VECTOR_SCALING;
-    case rocsparselt_matmul_bias_stride:
-        return HIPSPARSELT_MATMUL_BIAS_STRIDE;
-    case rocsparselt_matmul_bias_pointer:
-        return HIPSPARSELT_MATMUL_BIAS_POINTER;
-    case rocsparselt_matmul_activation_abs:
-        return HIPSPARSELT_MATMUL_ACTIVATION_ABS;
-    case rocsparselt_matmul_activation_leakyrelu:
-        return HIPSPARSELT_MATMUL_ACTIVATION_LEAKYRELU;
-    case rocsparselt_matmul_activation_leakyrelu_alpha:
-        return HIPSPARSELT_MATMUL_ACTIVATION_LEAKYRELU_ALPHA;
-    case rocsparselt_matmul_activation_sigmoid:
-        return HIPSPARSELT_MATMUL_ACTIVATION_SIGMOID;
-    case rocsparselt_matmul_activation_tanh:
-        return HIPSPARSELT_MATMUL_ACTIVATION_TANH;
-    case rocsparselt_matmul_activation_tanh_alpha:
-        return HIPSPARSELT_MATMUL_ACTIVATION_TANH_ALPHA;
-    case rocsparselt_matmul_activation_tanh_beta:
-        return HIPSPARSELT_MATMUL_ACTIVATION_TANH_BETA;
-    case rocsparselt_matmul_bias_type:
-        return HIPSPARSELT_MATMUL_BIAS_TYPE;
-    default:
-        throw HIPSPARSE_STATUS_NOT_SUPPORTED;
-    }
-}
-
-hipsparseLtMatDescAttribute_t
-    RocSparseLtMatDescAttributeToHIPMatDescAttribute(rocsparselt_mat_descr_attribute_ attr)
-{
-    switch(attr)
-    {
-    case rocsparselt_mat_num_batches:
-        return HIPSPARSELT_MAT_NUM_BATCHES;
-    case rocsparselt_mat_batch_stride:
-        return HIPSPARSELT_MAT_BATCH_STRIDE;
-    default:
-        throw HIPSPARSE_STATUS_NOT_SUPPORTED;
-    }
-}
 
 rocsparselt_mat_descr_attribute_
     HIPMatDescAttributeToRocSparseLtMatDescAttribute(hipsparseLtMatDescAttribute_t attr)
@@ -312,17 +218,6 @@ rocsparselt_matmul_alg_ HIPMatmulAlgToRocSparseLtMatmulAlg(hipsparseLtMatmulAlg_
     {
     case HIPSPARSELT_MATMUL_ALG_DEFAULT:
         return rocsparselt_matmul_alg_default;
-    default:
-        throw HIPSPARSE_STATUS_NOT_SUPPORTED;
-    }
-}
-
-hipsparseLtMatmulAlg_t RocSparseLtMatmulAlgToHIPMatmulAlg(rocsparselt_matmul_alg_ alg)
-{
-    switch(alg)
-    {
-    case rocsparselt_matmul_alg_default:
-        return HIPSPARSELT_MATMUL_ALG_DEFAULT;
     default:
         throw HIPSPARSE_STATUS_NOT_SUPPORTED;
     }
@@ -350,28 +245,6 @@ rocsparselt_matmul_alg_attribute_
     }
 }
 
-hipsparseLtMatmulAlgAttribute_t
-    RocSparseLtAlgAttributeToHIPMatmulAlgAttribute(rocsparselt_matmul_alg_attribute_ alg)
-{
-    switch(alg)
-    {
-    case rocsparselt_matmul_alg_config_id:
-        return HIPSPARSELT_MATMUL_ALG_CONFIG_ID;
-    case rocsparselt_matmul_alg_config_max_id:
-        return HIPSPARSELT_MATMUL_ALG_CONFIG_MAX_ID;
-    case rocsparselt_matmul_search_iterations:
-        return HIPSPARSELT_MATMUL_SEARCH_ITERATIONS;
-    case rocsparselt_matmul_split_k:
-        return HIPSPARSELT_MATMUL_SPLIT_K;
-    case rocsparselt_matmul_split_k_mode:
-        return HIPSPARSELT_MATMUL_SPLIT_K_MODE;
-    case rocsparselt_matmul_split_k_buffers:
-        return HIPSPARSELT_MATMUL_SPLIT_K_BUFFERS;
-    default:
-        throw HIPSPARSE_STATUS_NOT_SUPPORTED;
-    }
-}
-
 rocsparselt_prune_alg_ HIPPruneAlgToRocSparseLtPruneAlg(hipsparseLtPruneAlg_t alg)
 {
     switch(alg)
@@ -385,19 +258,6 @@ rocsparselt_prune_alg_ HIPPruneAlgToRocSparseLtPruneAlg(hipsparseLtPruneAlg_t al
     }
 }
 
-hipsparseLtPruneAlg_t RocSparseLtPruneAlgToHIPPruneAlg(rocsparselt_prune_alg_ alg)
-{
-    switch(alg)
-    {
-    case rocsparselt_prune_smfmac_tile:
-        return HIPSPARSELT_PRUNE_SPMMA_TILE;
-    case rocsparselt_prune_smfmac_strip:
-        return HIPSPARSELT_PRUNE_SPMMA_STRIP;
-    default:
-        throw HIPSPARSE_STATUS_NOT_SUPPORTED;
-    }
-}
-
 rocsparselt_split_k_mode HIPSplitKModeToRocSparseLtSplitKMode(hipsparseLtSplitKMode_t mode)
 {
     switch(mode)
@@ -406,19 +266,6 @@ rocsparselt_split_k_mode HIPSplitKModeToRocSparseLtSplitKMode(hipsparseLtSplitKM
         return rocsparselt_splik_k_mode_one_kernel;
     case HIPSPARSELT_SPLIT_K_MODE_TWO_KERNELS:
         return rocsparselt_split_k_mode_two_kernels;
-    default:
-        throw HIPSPARSE_STATUS_NOT_SUPPORTED;
-    }
-}
-
-hipsparseLtSplitKMode_t RocSparseLtSplitKModeToHIPSplitKMode(rocsparselt_split_k_mode mode)
-{
-    switch(mode)
-    {
-    case rocsparselt_splik_k_mode_one_kernel:
-        return HIPSPARSELT_SPLIT_K_MODE_ONE_KERNEL;
-    case rocsparselt_split_k_mode_two_kernels:
-        return HIPSPARSELT_SPLIT_K_MODE_TWO_KERNELS;
     default:
         throw HIPSPARSE_STATUS_NOT_SUPPORTED;
     }

--- a/library/src/hcc_detail/rocsparselt/src/handle.cpp
+++ b/library/src/hcc_detail/rocsparselt/src/handle.cpp
@@ -137,7 +137,7 @@ std::ostream& operator<<(std::ostream& stream, const _rocsparselt_mat_descr& t)
     stream << "{"
            << "ptr=" << (&t) << ", format=" << rocsparselt_matrix_type_to_string(t.m_type)
            << ", row=" << t.m << ", col=" << t.n << ", ld=" << t.ld << ", alignment=" << t.alignment
-           << ", datatype=" << hipDataType_to_string(t.type)
+           << ", datatype=" << hip_datatype_to_string(t.type)
            << ", order=" << rocsparselt_order_to_string(t.order);
     if(t.m_type == rocsparselt_matrix_type_structured)
         stream << ", sparsity=" << rocsparselt_sparsity_to_string(t.sparsity);
@@ -163,7 +163,7 @@ std::ostream& operator<<(std::ostream& stream, const _rocsparselt_matmul_descr& 
            << ", activation_tanh_beta=" << t.activation_tanh_beta
            << ", activation_gelu_scaling=" << t.activation_gelu_scaling
            << ", bias_pointer=" << t.bias_pointer << ", bias_stride=" << t.bias_stride
-           << ", bias_type=" << hipDataType_to_string(t.bias_type) << ", m=" << t.m << ", n=" << t.n
+           << ", bias_type=" << hip_datatype_to_string(t.bias_type) << ", m=" << t.m << ", n=" << t.n
            << ", k=" << t.k << ", is_sparse_a=" << t.is_sparse_a << "}";
     return stream;
 }

--- a/library/src/hcc_detail/rocsparselt/src/include/rocsparselt_spmm_utils.hpp
+++ b/library/src/hcc_detail/rocsparselt/src/include/rocsparselt_spmm_utils.hpp
@@ -267,7 +267,7 @@ inline rocsparselt_status validateMatrixArgs(const _rocsparselt_handle* handle,
             break;
 #endif
     default:
-        hipsparselt_cerr << "datatype (" << hipDataType_to_string(valueType) << ") is not supported"
+        hipsparselt_cerr << "datatype (" << hip_datatype_to_string(valueType) << ") is not supported"
                          << std::endl;
         log_error(handle, __func__, "datatype is not supported");
         return rocsparselt_status_not_implemented;
@@ -357,10 +357,10 @@ inline rocsparselt_status validateMatmulDescrArgs(const _rocsparselt_handle* han
         else
         {
             std::ostringstream stringStream;
-            stringStream << "datatype A=" << hipDataType_to_string(type_a);
-            stringStream << " B=" << hipDataType_to_string(type_b);
-            stringStream << " C=" << hipDataType_to_string(type_c);
-            stringStream << " D=" << hipDataType_to_string(type_d);
+            stringStream << "datatype A=" << hip_datatype_to_string(type_a);
+            stringStream << " B=" << hip_datatype_to_string(type_b);
+            stringStream << " C=" << hip_datatype_to_string(type_c);
+            stringStream << " D=" << hip_datatype_to_string(type_d);
             stringStream << " computeType=" << rocsparselt_compute_type_to_string(compute_type);
             stringStream << " is not supported";
             auto msg = stringStream.str();

--- a/library/src/hcc_detail/rocsparselt/src/include/tensile_host.hpp
+++ b/library/src/hcc_detail/rocsparselt/src/include/tensile_host.hpp
@@ -473,7 +473,7 @@ struct RocsparseltContractionProblem
                             "bias_stride",
                             prob.bias_stride,
                             "bias_type",
-                            hipDataType_to_string(prob.bias_type),
+                            hip_datatype_to_string(prob.bias_type),
                             "alpha_vector_scaling",
                             prob.alpha_vector_scaling));
     };

--- a/library/src/hcc_detail/rocsparselt/src/include/utility.hpp
+++ b/library/src/hcc_detail/rocsparselt/src/include/utility.hpp
@@ -40,7 +40,6 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-hipsparseLtComputetype_t RocSparseLtComputetypeToHIPComputetype(rocsparselt_compute_type_ type);
 hipsparseOperation_t     HCCOperationToHIPOperation(rocsparselt_operation_ op);
 #ifdef __cplusplus
 }
@@ -49,18 +48,6 @@ hipsparseOperation_t     HCCOperationToHIPOperation(rocsparselt_operation_ op);
 inline bool isAligned(const void* pointer, size_t byte_count)
 {
     return reinterpret_cast<uintptr_t>(pointer) % byte_count == 0;
-}
-
-// return precision string for hipDataType
-constexpr const char* hipDataType_string(hipDataType type)
-{
-    return hip_datatype_to_string(type);
-}
-
-// return precision string for rocsparselt_compute_type
-constexpr const char* rocsparselt_compute_type_string(rocsparselt_compute_type type)
-{
-    return hipsparselt_computetype_to_string(RocSparseLtComputetypeToHIPComputetype(type));
 }
 
 constexpr const char* rocsparselt_transpose_letter(rocsparselt_operation op)
@@ -92,8 +79,6 @@ template <>
 static constexpr char rocsparselt_precision_string<__hip_fp8_e5m2>[] = "bf8_r";
 
 std::string prefix(const char* layer, const char* caller);
-
-const char* hipDataType_to_string(hipDataType type);
 
 const char* rocsparselt_compute_type_to_string(rocsparselt_compute_type type);
 

--- a/library/src/hcc_detail/rocsparselt/src/rocsparselt_auxiliary.cpp
+++ b/library/src/hcc_detail/rocsparselt/src/rocsparselt_auxiliary.cpp
@@ -178,7 +178,7 @@ rocsparselt_status rocsparselt_dense_descr_init(const rocsparselt_handle* handle
                     "alignment[in]",
                     alignment,
                     "valueType[in]",
-                    hipDataType_to_string(valueType),
+                    hip_datatype_to_string(valueType),
                     "order[in]",
                     rocsparselt_order_to_string(order));
         }
@@ -269,7 +269,7 @@ rocsparselt_status rocsparselt_structured_descr_init(const rocsparselt_handle* h
                     "alignment[in]",
                     alignment,
                     "valueType[in]",
-                    hipDataType_to_string(valueType),
+                    hip_datatype_to_string(valueType),
                     "order[in]",
                     rocsparselt_order_to_string(order),
                     "sparsity[in]",

--- a/library/src/hcc_detail/rocsparselt/src/spmm/rocsparselt_compress.cpp
+++ b/library/src/hcc_detail/rocsparselt/src/spmm/rocsparselt_compress.cpp
@@ -258,7 +258,7 @@ rocsparselt_status rocsparselt_smfmac_compress_impl(const _rocsparselt_handle*  
         log_error(handle,
                   "rocsparselt_smfmac_compress",
                   "datatype",
-                  hipDataType_to_string(type),
+                  hip_datatype_to_string(type),
                   "is not supported");
         return rocsparselt_status_not_implemented;
     }

--- a/library/src/hcc_detail/rocsparselt/src/spmm/rocsparselt_prune.cpp
+++ b/library/src/hcc_detail/rocsparselt/src/spmm/rocsparselt_prune.cpp
@@ -613,7 +613,7 @@ rocsparselt_status rocsparselt_smfmac_prune_impl(const _rocsparselt_handle*    h
         log_error(handle,
                   "rocsparselt_smfmac_prune",
                   "datatype",
-                  hipDataType_to_string(type),
+                  hip_datatype_to_string(type),
                   "is not supported");
         return rocsparselt_status_not_implemented;
     }
@@ -669,7 +669,7 @@ rocsparselt_status rocsparselt_smfmac_prune_check_impl(const _rocsparselt_handle
         log_error(handle,
                   "rocsparselt_smfmac_prune_check",
                   "datatype",
-                  hipDataType_to_string(type),
+                  hip_datatype_to_string(type),
                   "is not supported");
         return rocsparselt_status_not_implemented;
     }

--- a/library/src/hcc_detail/rocsparselt/src/utility.cpp
+++ b/library/src/hcc_detail/rocsparselt/src/utility.cpp
@@ -48,29 +48,6 @@ std::string prefix(const char* layer, const char* caller)
     return std::string(buf.get());
 }
 
-const char* hipDataType_to_string(hipDataType type)
-{
-    switch(type)
-    {
-    case HIP_R_16F:
-        return "f16_r";
-    case HIP_R_32F:
-        return "f32_r";
-    case HIP_R_8I:
-        return "i8_r";
-    case HIP_R_16BF:
-        return "bf16_r";
-#if HIP_FP8_TYPE_OCP
-    case HIP_R_8F_E4M3:
-        return "f8_r";
-    case HIP_R_8F_E5M2:
-        return "bf8_r";
-#endif
-    default:
-        return "Invalid";
-    }
-}
-
 const char* rocsparselt_compute_type_to_string(rocsparselt_compute_type type)
 {
     switch(type)


### PR DESCRIPTION
 * RocSparseLtComputetypeToHIPComputetype
 * RocSparseLtSparsityToHIPSparsity
 * RocSparseLtMatmulDescAttributeToHIPMatmulDescAttribute
 * RocSparseLtMatDescAttributeToHIPMatDescAttribute
 * RocSparseLtAlgAttributeToHIPMatmulAlgAttribute
 * RocSparseLtPruneAlgToHIPPruneAlg
 * RocSparseLtSplitKModeToHIPSplitKMode
 * hipDataType_to_string
 * rocsparselt_compute_type_string