### PR TITLE
Remove File reorganization backward compatibility (hipSPARSELt)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -315,16 +315,6 @@ if( BUILD_CLIENTS_SAMPLES OR BUILD_CLIENTS_TESTS OR BUILD_CLIENTS_BENCHMARKS )
   endif()
 endif()
 
-# FOR HANDLING ENABLE/DISABLE OPTIONAL BACKWARD COMPATIBILITY for FILE/FOLDER REORG
-option(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY "Build with file/folder reorg with backward compatibility enabled" ON)
-if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
-  rocm_wrap_header_dir(
-    ${CMAKE_SOURCE_DIR}/library/include
-    PATTERNS "*.h"
-    GUARDS SYMLINK WRAPPER
-    WRAPPER_LOCATIONS include
-  )
-endif()
 add_subdirectory( library )
 
 # Trigger client builds if selected

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -174,14 +174,6 @@ endif()
 include( GenerateExportHeader )
 generate_export_header( hipsparselt EXPORT_FILE_NAME ${PROJECT_BINARY_DIR}/include/hipsparselt/hipsparselt-export.h)
 
-if (BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
-  rocm_wrap_header_file(
-    hipsparselt-version.h hipsparselt-export.h
-    GUARDS SYMLINK WRAPPER
-    WRAPPER_LOCATIONS include hipsparselt/include
-  )
-endif( )
-
 # Following Boost conventions of prefixing 'lib' on static built libraries, across all platforms
 if( NOT BUILD_SHARED_LIBS )
   set_target_properties( hipsparselt PROPERTIES PREFIX "lib" )
@@ -239,11 +231,3 @@ else( )
 	NAMESPACE roc::
     )
 endif( )
-
-if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
-  rocm_install(
-    DIRECTORY
-       "${PROJECT_BINARY_DIR}/hipsparselt"
-        DESTINATION "." )
-  message( STATUS "Backward Compatible Sym Link Created for include directories" )
-endif()


### PR DESCRIPTION
Summary of proposed changes:
remove backwards compatibility code. Feature has been disabled related code is not needed.