### PR TITLE
Revert "[Workaround] "-lflang_rt.runtime" not ready so use "-lFortranRuntime -lFortranDecimal" to instead."

### DIFF
--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -81,7 +81,7 @@ if (NOT WIN32)
   if (CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
     list( APPEND COMMON_LINK_LIBS "-lgfortran") # for lapack
   else()
-    list( APPEND COMMON_LINK_LIBS "-lFortranRuntime -lFortranDecimal") # for lapack
+    list( APPEND COMMON_LINK_LIBS "-lflang_rt.runtime") # for lapack
   endif()
 else()
   list( APPEND COMMON_LINK_LIBS "libomp")

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -90,7 +90,7 @@ list( APPEND COMMON_LINK_LIBS "-lm -lstdc++fs")
 if (CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
   list( APPEND COMMON_LINK_LIBS "-lgfortran") # for lapack
 else()
-  list( APPEND COMMON_LINK_LIBS "-lFortranRuntime -lFortranDecimal") # for lapack
+  list( APPEND COMMON_LINK_LIBS "-lflang_rt.runtime") # for lapack
 endif()
 
 #if (NOT WIN32)


### PR DESCRIPTION
This reverts commit 30d3458c4603d6addfc2453b86b23cdd214c1747.

This is an experiment PR, please don't merge it.